### PR TITLE
Add plugin-specific tests and static asset folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 site/
+**/__pycache__/

--- a/README.md
+++ b/README.md
@@ -46,3 +46,22 @@ plugins:
 ```
 
 Il plugin `cookieconsent` integra la libreria [cookieconsent](https://github.com/orestbida/cookieconsent) e carica Google Analytics solo dopo il consenso. L'ID di tracciamento va specificato nella variabile `COOKIECONSENT_GA_ID` sempre nel file di configurazione.
+
+## Cartella `static`
+
+Nel repository è presente anche una cartella `static/` destinata a eventuali
+asset statici globali del sito. Contiene un semplice README solo per mantenere
+la directory sotto version control.
+
+## Test
+
+Prima di generare il sito è consigliato eseguire i test automatici tramite lo
+script `run_tests.py`:
+
+```bash
+python run_tests.py
+```
+
+Lo script esegue i test del core e quindi quelli dei plugin elencati in
+`config.yml`. Ogni plugin può definire i propri test nella cartella
+`plugins/<nome>/tests/`.

--- a/plugins/cookieconsent/tests/test_cookieconsent.py
+++ b/plugins/cookieconsent/tests/test_cookieconsent.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))
+import generate_site
+
+pytestmark = pytest.mark.skipif('cookieconsent' not in generate_site.PLUGINS, reason='cookieconsent plugin not active')
+
+
+def test_ga_id_rendered(monkeypatch):
+    monkeypatch.setattr(generate_site, 'PLUGINS', ['cookieconsent'])
+    env = generate_site.load_templates()
+    ga_id = generate_site.config['COOKIECONSENT_GA_ID']
+    assert any(ga_id in snippet for snippet in env.globals['plugins_body'])

--- a/plugins/example/tests/test_example.py
+++ b/plugins/example/tests/test_example.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))
+import generate_site
+
+pytestmark = pytest.mark.skipif('example' not in generate_site.PLUGINS, reason='example plugin not active')
+
+
+def test_example_snippets(monkeypatch):
+    monkeypatch.setattr(generate_site, 'PLUGINS', ['example'])
+    plugins = generate_site.load_plugins()
+    assert any('Example plugin header' in s for s in plugins['head'])
+    assert any('Plugin example active' in s for s in plugins['body'])
+
+
+def test_example_static_copy(monkeypatch, tmp_path):
+    monkeypatch.setattr(generate_site, 'PLUGINS', ['example'])
+    monkeypatch.setattr(generate_site, 'OUTPUT_DIR', tmp_path)
+    generate_site.copy_plugin_static()
+    expected = tmp_path / 'plugins' / 'example' / 'example.css'
+    assert expected.exists()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 markdown
 jinja2
 pyyaml
+pytest

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Run core tests and tests for each active plugin."""
+
+import subprocess
+from pathlib import Path
+import generate_site
+
+
+def main():
+    # run core tests
+    subprocess.check_call(['pytest', 'tests'])
+    # run tests for each active plugin
+    for name in generate_site.PLUGINS:
+        plugin_tests = Path('plugins') / name / 'tests'
+        if plugin_tests.is_dir():
+            subprocess.check_call(['pytest', str(plugin_tests)])
+
+
+if __name__ == '__main__':
+    main()

--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,1 @@
+Static assets for the blog.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import generate_site
+
+
+def test_main_generates_output(monkeypatch, tmp_path):
+    output = tmp_path / 'site'
+    monkeypatch.setattr(generate_site, 'OUTPUT_DIR', output)
+    generate_site.main()
+    assert (output / 'index.html').exists()
+    assert (output / 'about.html').exists()
+    assert (output / 'posts').exists()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,18 @@
+import tempfile
+from pathlib import Path
+import generate_site
+
+
+def test_load_plugins(monkeypatch):
+    monkeypatch.setattr(generate_site, 'PLUGINS', ['example'])
+    plugins = generate_site.load_plugins()
+    assert any('Example plugin header' in s for s in plugins['head'])
+    assert any('Plugin example active' in s for s in plugins['body'])
+
+
+def test_copy_plugin_static(monkeypatch, tmp_path):
+    monkeypatch.setattr(generate_site, 'PLUGINS', ['example'])
+    monkeypatch.setattr(generate_site, 'OUTPUT_DIR', tmp_path)
+    generate_site.copy_plugin_static()
+    expected_file = tmp_path / 'plugins' / 'example' / 'example.css'
+    assert expected_file.exists()


### PR DESCRIPTION
## Summary
- add `run_tests.py` to execute core tests and those of active plugins
- place plugin-specific tests under each plugin's `tests` folder
- document `run_tests.py` in README and mention new `static/` folder
- ignore `__pycache__` recursively

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_683ab19a8404833184f1a8cbeae793bd