### PR TITLE
Add integration tests for plugins

### DIFF
--- a/plugins/cookieconsent/tests/test_cookieconsent.py
+++ b/plugins/cookieconsent/tests/test_cookieconsent.py
@@ -14,3 +14,11 @@ def test_ga_id_rendered(monkeypatch):
     env = generate_site.load_templates()
     ga_id = generate_site.config['COOKIECONSENT_GA_ID']
     assert any(ga_id in snippet for snippet in env.globals['plugins_body'])
+
+def test_cookieconsent_in_generated_site(monkeypatch, tmp_path):
+    monkeypatch.setattr(generate_site, 'PLUGINS', ['cookieconsent'])
+    monkeypatch.setattr(generate_site, 'OUTPUT_DIR', tmp_path)
+    generate_site.main()
+    html = (tmp_path / 'index.html').read_text(encoding='utf-8')
+    assert 'cookieconsent.min.js' in html
+    assert generate_site.config['COOKIECONSENT_GA_ID'] in html

--- a/plugins/example/tests/test_example.py
+++ b/plugins/example/tests/test_example.py
@@ -22,3 +22,11 @@ def test_example_static_copy(monkeypatch, tmp_path):
     generate_site.copy_plugin_static()
     expected = tmp_path / 'plugins' / 'example' / 'example.css'
     assert expected.exists()
+
+def test_example_snippet_in_generated_site(monkeypatch, tmp_path):
+    monkeypatch.setattr(generate_site, 'PLUGINS', ['example'])
+    monkeypatch.setattr(generate_site, 'OUTPUT_DIR', tmp_path)
+    generate_site.main()
+    html = (tmp_path / 'index.html').read_text(encoding='utf-8')
+    assert 'Plugin example active' in html
+    assert 'plugins/example/static/example.css' in html


### PR DESCRIPTION
## Summary
- extend example plugin tests to verify snippets in generated HTML
- extend cookieconsent plugin tests likewise

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ade44a4e48331af0176a72e21eaf5