### PR TITLE
Fix: Add error handling to cookieconsent and temporarily disable GA load



### DIFF
--- a/plugins/cookieconsent/body.html
+++ b/plugins/cookieconsent/body.html
@@ -1,6 +1,7 @@
 <script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+try {
   var cc = initCookieConsent();
   cc.run({
     guiOptions: {
@@ -12,14 +13,14 @@ document.addEventListener('DOMContentLoaded', function () {
       analytics: {}
     },
     onFirstAction: function(user_preferences, cookie){
-      if (cc.allowedCategory('analytics')) {
-        loadAnalytics();
-      }
+      // if (cc.allowedCategory('analytics')) {
+      //   loadAnalytics();
+      // }
     },
     onAccept: function(cookie){
-      if (cc.allowedCategory('analytics')) {
-        loadAnalytics();
-      }
+      // if (cc.allowedCategory('analytics')) {
+      //   loadAnalytics();
+      // }
     }
   });
 
@@ -37,4 +38,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 });
+} catch (error) {
+  console.error("CookieConsent Initialization Error:", error);
+}
 </script>


### PR DESCRIPTION
This change wraps the cookie consent initialization in a try-catch block to log potential errors. It also temporarily comments out the Google Analytics loading within the cookie consent script to isolate potential issues caused by the placeholder GA ID. This is to help diagnose why the cookie banner and example plugin log might not be appearing.