### PR TITLE
Add devcontainer for VSCode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "name": "PyBlog Dev Container",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
+    "postCreateCommand": "pip install -r requirements.txt",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a default devcontainer configuration for VS Code

## Testing
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_b_683ea45ea5fc8331aef9c31ca3fe4f9e