### PR TITLE
Add serve_site utility and open port

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
     "name": "PyBlog Dev Container",
     "image": "mcr.microsoft.com/devcontainers/python:3.12",
     "postCreateCommand": "pip install -r requirements.txt",
+    "forwardPorts": [8000],
     "customizations": {
         "vscode": {
             "extensions": [

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ python3 generate_site.py
 
 Il risultato viene scritto nella cartella `site/`.
 
+Per visualizzare in locale il sito generato è disponibile lo script `serve_site.py`:
+
+```bash
+python3 serve_site.py
+```
+
+Il server utilizza la cartella `site/` e per default espone la porta `8000`.
+
 ## Plugin
 
 È possibile estendere il sito posizionando dei frammenti di codice HTML nella

--- a/serve_site.py
+++ b/serve_site.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Simple HTTP server to serve the generated site directory."""
+import http.server
+import socketserver
+import argparse
+from pathlib import Path
+
+DEFAULT_PORT = 8000
+
+parser = argparse.ArgumentParser(description="Serve the generated site locally")
+parser.add_argument("--port", "-p", type=int, default=DEFAULT_PORT,
+                    help="Port to bind the HTTP server")
+args = parser.parse_args()
+
+site_dir = Path(__file__).resolve().parent / "site"
+if not site_dir.is_dir():
+    raise SystemExit(f"Cartella 'site' non trovata: {site_dir}")
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    # Silence logging to keep output clean
+    def log_message(self, format, *args):
+        pass
+
+handler = QuietHandler
+
+with socketserver.TCPServer(("0.0.0.0", args.port), handler) as httpd:
+    print(f"Serving '{site_dir}' at http://localhost:{args.port}")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nServer stopped")


### PR DESCRIPTION
## Summary
- provide `serve_site.py` for serving the generated site directory
- open port 8000 in the devcontainer
- document the new script in the README

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_683ea93200088331aaf694896b1ef684