### PR TITLE
Allow overriding base_url via env or CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ python3 serve_site.py
 
 Il server utilizza la cartella `site/` e per default espone la porta `8000`.
 
+### Gestione ambienti
+
+Per sovrascrivere la `base_url` definita in `config.yml` senza modificare il file
+si può usare la variabile d'ambiente `PYBLOG_BASE_URL` oppure l'opzione
+`--base-url` dello script:
+
+```bash
+PYBLOG_BASE_URL=http://localhost:8000/ python3 generate_site.py
+# oppure
+python3 generate_site.py --base-url http://localhost:8000/
+```
+
 ## Plugin
 
 È possibile estendere il sito posizionando dei frammenti di codice HTML nella

--- a/generate_site.py
+++ b/generate_site.py
@@ -23,6 +23,8 @@ import yaml
 import markdown
 from jinja2 import Environment, FileSystemLoader
 from datetime import datetime
+import os
+import argparse
 
 PLUGINS_DIR = Path('plugins')
 
@@ -38,7 +40,7 @@ with CONFIG_PATH.open(encoding='utf-8') as f:
 PLUGINS = config.get('plugins', [])
 
 # Parametri da config
-BASE_URL      = config.get('base_url', '/')
+BASE_URL      = os.getenv('PYBLOG_BASE_URL', config.get('base_url', '/'))
 OUTPUT_DIR    = Path(config.get('output_dir', 'site/'))
 CONTENT_PAGES = Path(config['content']['pages'])
 CONTENT_POSTS = Path(config['content']['posts'])
@@ -353,4 +355,10 @@ def main():
     print(f"Generazione completata in [{OUTPUT_DIR}]/ con template in [templates]/. Base URL: {BASE_URL}")
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Generate the static site")
+    parser.add_argument("--base-url", help="Override base_url from config or env")
+    args = parser.parse_args()
+
+    if args.base_url:
+        BASE_URL = args.base_url
     main()


### PR DESCRIPTION
## Summary
- allow overriding `base_url` with `PYBLOG_BASE_URL` environment variable
- add `--base-url` option to `generate_site.py`
- document how to use it in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683eab9afdac8331af6f7e338aa843d8