### PR TITLE
Fix serve_site using wrong directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ in HTML utilizzando Jinja2 e Tailwind CSS.
 python3 generate_site.py
 ```
 
-Il risultato viene scritto nella cartella `site/`.
+Il risultato viene scritto nella cartella indicata da `output_dir` in `config.yml` (di default `site/`).
 
 Per visualizzare in locale il sito generato è disponibile lo script `serve_site.py`:
 
@@ -17,7 +17,7 @@ Per visualizzare in locale il sito generato è disponibile lo script `serve_site
 python3 serve_site.py
 ```
 
-Il server utilizza la cartella `site/` e per default espone la porta `8000`.
+Il server utilizza la stessa cartella indicata da `output_dir` (per default `site/`) e per default espone la porta `8000`.
 
 ### Gestione ambienti
 
@@ -39,7 +39,7 @@ file seguenti:
 
 - `head.html` – inserito nell'elemento `<head>` di ogni pagina.
 - `body.html` – inserito prima della chiusura di `<body>`.
-- `static/` – cartella opzionale che verrà copiata in `site/plugins/<nome>`.
+- `static/` – cartella opzionale che verrà copiata in `<output_dir>/plugins/<nome>` (dove `<output_dir>` è definito in `config.yml`).
 
 Esempio di struttura:
 

--- a/serve_site.py
+++ b/serve_site.py
@@ -4,6 +4,8 @@ import http.server
 import socketserver
 import argparse
 from pathlib import Path
+import yaml
+import os
 
 DEFAULT_PORT = 8000
 
@@ -12,9 +14,21 @@ parser.add_argument("--port", "-p", type=int, default=DEFAULT_PORT,
                     help="Port to bind the HTTP server")
 args = parser.parse_args()
 
-site_dir = Path(__file__).resolve().parent / "site"
+# Load configuration to determine the output directory
+script_dir = Path(__file__).resolve().parent
+config_path = script_dir / "config.yml"
+if not config_path.exists():
+    raise SystemExit("File di configurazione 'config.yml' non trovato")
+with config_path.open(encoding="utf-8") as f:
+    config = yaml.safe_load(f)
+
+output_dir = Path(config.get("output_dir", "site/"))
+site_dir = output_dir if output_dir.is_absolute() else script_dir / output_dir
 if not site_dir.is_dir():
-    raise SystemExit(f"Cartella 'site' non trovata: {site_dir}")
+    raise SystemExit(f"Cartella '{output_dir}' non trovata: {site_dir}")
+
+# Change working directory so the HTTP server serves from the configured output directory
+os.chdir(site_dir)
 
 class QuietHandler(http.server.SimpleHTTPRequestHandler):
     # Silence logging to keep output clean


### PR DESCRIPTION
## Summary
- ensure serve_site.py actually serves from the `site/` directory

## Testing
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_b_683eaf5910948331bfc6d0faf6935f71