### PR TITLE
Replace Bulma CSS with Bootstrap 5.3

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -1,38 +1,20 @@
-/* Custom styles for Bulma's 'content' class */
-.content h1, .content h2, .content h3, .content h4, .content h5, .content h6 {
-    margin-bottom: 0.75em; /* Ensure consistent bottom margin for headings */
-    font-weight: 600; /* Slightly bolder headings by default */
-}
-
-.content p {
+/* Custom styles for article content */
+article p {
     margin-bottom: 1.25em; /* More spacious paragraphs */
     line-height: 1.7;   /* Improved line height for readability */
 }
 
-.content ul, .content ol {
-    margin-left: 2em;     /* Standard indentation for lists */
-    margin-bottom: 1.25em;
-}
-
-.content li {
+article li {
     margin-bottom: 0.5em; /* Spacing between list items */
 }
 
-.content blockquote {
-    background-color: hsl(0, 0%, 96%); /* Default Bulma grey for blockquotes */
-    border-left: 5px solid hsl(0, 0%, 86%); /* Default Bulma grey-light for border */
+article blockquote {
+    background-color: hsl(0, 0%, 96%);
+    border-left: 5px solid hsl(0, 0%, 86%);
     padding: 1em 1.5em;
     margin-bottom: 1.5em;
 }
 
-.content a {
-    /* If you want to customize link color within .content.
-       Bulma's default is often fine. Example:
-       color: hsl(217, 71%, 53%);
-    */
-    /* text-decoration: underline; /* Uncomment if you always want underlines */
-}
-
-.content hr {
+article hr {
     margin: 2em 0; /* More spacing around horizontal rules */
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,33 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ title }}</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <link rel="stylesheet" href="{{ base_url }}static/custom.css">
   {% for snippet in plugins_head %}
   {{ snippet | safe }}
   {% endfor %}
 </head>
 <body>
-  <nav class="navbar is-light has-shadow" role="navigation" aria-label="main navigation">
+  <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm" role="navigation" aria-label="main navigation">
     <div class="container">
-      <div class="navbar-brand">
-        <a href="{{ base_url }}" class="navbar-item is-size-4">{{ site_title }}</a>
-
-        <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
-          <span aria-hidden="true"></span>
-          <span aria-hidden="true"></span>
-          <span aria-hidden="true"></span>
-        </a>
-      </div>
-
-      <div id="navbarBasicExample" class="navbar-menu">
-        <div class="navbar-start">
-          <a href="{{ base_url }}" class="navbar-item">Home</a>
-          <a href="{{ base_url }}about.html" class="navbar-item">About</a>
-          <a href="{{ base_url }}tags.html" class="navbar-item">Tags</a>
-        </div>
-
-        <div class="navbar-end">
+      <a href="{{ base_url }}" class="navbar-brand fs-4">{{ site_title }}</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarBasicExample" aria-controls="navbarBasicExample" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarBasicExample">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a href="{{ base_url }}" class="nav-link">Home</a></li>
+          <li class="nav-item"><a href="{{ base_url }}about.html" class="nav-link">About</a></li>
+          <li class="nav-item"><a href="{{ base_url }}tags.html" class="nav-link">Tags</a></li>
+        </ul>
+        <div class="navbar-nav ms-auto">
           <!-- Future elements can go here -->
         </div>
       </div>
@@ -38,22 +31,22 @@
   </nav>
 
 {% if config.site.hero_image_url %}
-<section class="hero is-medium">
-  <div class="hero-body" style="background-image: url('{{ config.site.hero_image_url }}'); background-size: cover; background-position: center;">
-    <!-- Removed img tag, using background image on hero-body -->
+<section class="py-5 mb-4 bg-light rounded-3">
+  <div style="background-image: url('{{ config.site.hero_image_url }}'); background-size: cover; background-position: center; min-height: 300px;">
+    <!-- Adjusted to ensure hero has some height if empty, min-height can be adjusted -->
   </div>
 </section>
 {% endif %}
-<section class="section">
+<section class="py-5">
   <div class="container">
-    <main class="mt-8"> <!-- Added mt-8 to main to compensate for fixed header - consider if still needed with Bulma sections -->
+    <main class="mt-4">
       {% block content %}{% endblock %}
     </main>
   </div>
 </section>
-<footer class="footer has-text-centered is-size-7 has-text-grey">
+<footer class="footer text-center text-muted small py-3">
   <div class="container">
-    <div class="content">
+    <div>
       <p>&copy; {{ now.year }} {{ site_title }}. Tutti i diritti riservati.</p>
     </div>
   </div>
@@ -61,5 +54,6 @@
   {% for snippet in plugins_body %}
   {{ snippet | safe }}
   {% endfor %}
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,48 +4,43 @@
 {# This hero image display is distinct from the one in base.html #}
 {# It will only show if config.site.hero_image_url is defined, and it's specific to index.html #}
 {% if config.site.hero_image_url %}
-<section class="has-text-centered mb-5">
-  <img src="{{ config.site.hero_image_url }}" alt="Hero Image" class="is-inline-block" style="max-height: 400px;">
+<section class="text-center mb-5">
+  <img src="{{ config.site.hero_image_url }}" alt="Hero Image" class="d-inline-block" style="max-height: 400px; max-width: 100%;">
 </section>
 {% endif %}
 
-<section class="mb-5"> {# Changed mb-8 to mb-5 to be consistent with Bulma spacing scale if needed #}
-  <h2 class="title is-3 mb-4">Ultimi Post</h2>
-  <ul>
+<section class="mb-5">
+  <h2 class="h3 mb-4">Ultimi Post</h2>
+  <ul class="list-unstyled">
   {% for post in posts %}
     <li class="mb-3">
-      <a href="{{ base_url }}{{ post.url }}" class="is-size-5">{{ post.title }}</a>
-      <span class="is-size-7 has-text-grey"> - {{ post.date }}</span>
+      <a href="{{ base_url }}{{ post.url }}" class="fs-5 text-decoration-none">{{ post.title }}</a>
+      <span class="small text-muted"> - {{ post.date }}</span>
     </li>
   {% endfor %}
   </ul>
 </section>
 
 {% if total_pages > 1 %}
-<nav class="pagination is-centered mt-5" role="navigation" aria-label="pagination">
-  {% if current_page > 1 %}
-    <a href="{{ base_url }}{% if current_page == 2 %}index.html{% else %}page/{{ current_page - 1 }}.html{% endif %}" class="pagination-previous">Previous</a>
-  {% else %}
-    <a class="pagination-previous" disabled>Previous</a>
-  {% endif %}
+<nav aria-label="pagination" class="mt-5">
+  <ul class="pagination justify-content-center">
+    <li class="page-item {% if current_page == 1 %}disabled{% endif %}">
+      <a href="{{ base_url }}{% if current_page == 2 %}index.html{% else %}page/{{ current_page - 1 }}.html{% endif %}" class="page-link">Previous</a>
+    </li>
 
-  {% if current_page < total_pages %}
-    <a href="{{ base_url }}page/{{ current_page + 1 }}.html" class="pagination-next">Next</a>
-  {% else %}
-    <a class="pagination-next" disabled>Next</a>
-  {% endif %}
-
-  <ul class="pagination-list">
     {% for page_num in range(1, total_pages + 1) %}
-    <li>
+    <li class="page-item {% if page_num == current_page %}active{% endif %}" {% if page_num == current_page %}aria-current="page"{% endif %}>
       <a href="{{ base_url }}{% if page_num == 1 %}index.html{% else %}page/{{ page_num }}.html{% endif %}"
-         class="pagination-link {% if page_num == current_page %}is-current{% endif %}"
-         aria-label="Goto page {{ page_num }}"
-         {% if page_num == current_page %}aria-current="page"{% endif %}>
+         class="page-link"
+         aria-label="Goto page {{ page_num }}">
         {{ page_num }}
       </a>
     </li>
     {% endfor %}
+
+    <li class="page-item {% if current_page == total_pages %}disabled{% endif %}">
+      <a href="{{ base_url }}page/{{ current_page + 1 }}.html" class="page-link">Next</a>
+    </li>
   </ul>
 </nav>
 {% endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<article class="content is-large box">
+<article class="p-4 border rounded shadow-sm">
   {{ content | safe }}
 </article>
 {% endblock %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,17 +1,17 @@
 {% extends 'base.html' %}
 {% block content %}
-<article class="content is-large box">
-  <h2 class="title is-3 mb-3">{{ title }}</h2>
-  <p class="subtitle is-size-7 has-text-grey mb-4">{{ date }}</p>
+<article class="p-4 border rounded shadow-sm">
+  <h2 class="h3 mb-3">{{ title }}</h2>
+  <p class="small text-muted mb-4">{{ date }}</p>
   {{ content | safe }}
 
   {% if tags %}
-  <hr class="is-medium">
+  <hr class="my-4">
   <div class="mt-5">
-    <h3 class="title is-5 mb-2">Tags:</h3>
-    <div class="tags">
+    <h3 class="h5 mb-2">Tags:</h3>
+    <div class="d-flex flex-wrap gap-2">
       {% for tag in tags %}
-      <a href="{{ base_url }}tags/{{ tag | slugify }}.html" class="tag is-light">{{ tag }}</a>
+      <a href="{{ base_url }}tags/{{ tag | slugify }}.html" class="badge text-bg-light text-decoration-none">{{ tag }}</a>
       {% endfor %}
     </div>
   </div>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -3,16 +3,16 @@
 {% block title %}Posts tagged with '{{ tag_name }}' - {{ site_title }}{% endblock %}
 
 {% block content %}
-<section class="mb-5"> {# Changed mb-8 to mb-5 for consistency #}
-  <h2 class="title is-3 mb-5">Posts tagged with '{{ tag_name }}'</h2>
+<section class="mb-5">
+  <h2 class="h3 mb-5">Posts tagged with '{{ tag_name }}'</h2>
   {% if posts %}
-  <ul>
+  <ul class="list-unstyled">
     {% for post in posts %}
     <li class="mb-4">
-      <h3 class="title is-4">
-        <a href="{{ base_url }}{{ post.url }}">{{ post.title }}</a>
+      <h3 class="h4">
+        <a href="{{ base_url }}{{ post.url }}" class="text-decoration-none">{{ post.title }}</a>
       </h3>
-      <p class="is-size-7 has-text-grey">{{ post.date.strftime('%d %B %Y') }}</p>
+      <p class="small text-muted">{{ post.date.strftime('%d %B %Y') }}</p>
     </li>
     {% endfor %}
   </ul>
@@ -22,6 +22,6 @@
 </section>
 
 <p class="mt-5">
-  <a href="{{ base_url }}tags.html">&larr; View all tags</a>
+  <a href="{{ base_url }}tags.html" class="text-decoration-none">&larr; View all tags</a>
 </p>
 {% endblock %}

--- a/templates/tags_list.html
+++ b/templates/tags_list.html
@@ -4,15 +4,15 @@
 
 {% block content %}
 <section class="mb-5">
-  <h2 class="title is-3 mb-5">All Tags</h2>
+  <h2 class="h3 mb-5">All Tags</h2>
   {% if tags %}
-  <ul>
+  <ul class="list-unstyled">
     {% for tag_info in tags %}
     <li class="mb-2">
-      <a href="{{ base_url }}{{ tag_info.url }}" class="is-size-5">
+      <a href="{{ base_url }}{{ tag_info.url }}" class="fs-5 text-decoration-none">
         {{ tag_info.name }}
       </a>
-      <span class="has-text-grey">({{ tag_info.count }} post{% if tag_info.count > 1 %}s{% endif %})</span>
+      <span class="text-muted">({{ tag_info.count }} post{% if tag_info.count > 1 %}s{% endif %})</span>
     </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
This commit replaces the Bulma CSS framework with Bootstrap 5.3 across your entire static site.

Key changes include:
- Updated `templates/base.html` to include Bootstrap 5.3 CSS and JS, and removed Bulma CSS.
- Migrated HTML structure and classes in `templates/base.html` from Bulma to Bootstrap for navbar, hero section, main content, and footer.
- Updated all other template files (`index.html`, `page.html`, `post.html`, `tag.html`, `tags_list.html`) to use Bootstrap classes and structure.
- Revised `static/custom.css` to be compatible with Bootstrap and removed redundant styles.
- Ensured site generation works correctly and basic structure of generated pages is sound with Bootstrap.