### PR TITLE
Fix hero image responsivity

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,7 @@ content:
 # Titolo del sito (opzionale)
 site:
   title: "Il Mio Blog"
-  hero_image_url: "" # URL for the hero image
+  hero_image_url: "images/hero-image.png" # URL for the hero image
 
 posts_per_page: 5
 

--- a/generate_site.py
+++ b/generate_site.py
@@ -25,10 +25,7 @@ from jinja2 import Environment, FileSystemLoader
 from datetime import datetime
 import os
 import argparse
-try:
-    from PIL import Image
-except ImportError:  # Pillow non installato
-    Image = None
+from PIL import Image
 import re
 
 PLUGINS_DIR = Path('plugins')
@@ -120,14 +117,6 @@ def optimize_images():
     """Genera versioni ottimizzate delle immagini presenti in static/images."""
     images_src = Path('static/images')
     if not images_src.is_dir():
-        return
-    if Image is None:
-        # Se Pillow non è disponibile, copia semplicemente le immagini
-        dest_dir = OUTPUT_DIR / 'images'
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        for img_path in images_src.iterdir():
-            if img_path.is_file():
-                shutil.copy2(img_path, dest_dir / img_path.name)
         return
 
     dest_dir = OUTPUT_DIR / 'images'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ markdown
 jinja2
 pyyaml
 pytest
+Pillow

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,14 @@
 {% extends 'base.html' %}
 {% block header %}
-<div class="container px-4 px-lg-5 my-4 text-center">
-  <img src="images/hero-image.png" alt="Hero image"
-       class="img-fluid rounded-top mx-auto mb-3">
-  <div class="site-heading">
-    <h1>{{ site_title }}</h1>
+<header class="masthead">
+  <div class="container px-4 px-lg-5 my-4 text-center">
+    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
+         class="img-fluid rounded-top mx-auto mb-3">
+    <div class="site-heading">
+      <h1>{{ site_title }}</h1>
+    </div>
   </div>
-</div>
+</header>
 {% endblock %}
 {% block content %}
 {% for post in posts %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,13 +1,11 @@
 {% extends 'base.html' %}
 {% block header %}
-<header class="masthead" style="background-image: url('{{ config.site.hero_image_url }}')">
-  <div class="container position-relative px-4 px-lg-5">
-    <div class="row gx-4 gx-lg-5 justify-content-center">
-      <div class="col-md-10 col-lg-8 col-xl-7">
-        <div class="page-heading">
-          <h1>{{ title }}</h1>
-        </div>
-      </div>
+<header class="masthead">
+  <div class="container px-4 px-lg-5 my-4 text-center">
+    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
+         class="img-fluid rounded-top mx-auto mb-3">
+    <div class="page-heading">
+      <h1>{{ title }}</h1>
     </div>
   </div>
 </header>

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,14 +1,12 @@
 {% extends 'base.html' %}
 {% block header %}
-<header class="masthead" style="background-image: url('{{ config.site.hero_image_url }}')">
-  <div class="container position-relative px-4 px-lg-5">
-    <div class="row gx-4 gx-lg-5 justify-content-center">
-      <div class="col-md-10 col-lg-8 col-xl-7">
-        <div class="post-heading">
-          <h1>{{ title }}</h1>
-          <span class="meta">{{ date }}</span>
-        </div>
-      </div>
+<header class="masthead">
+  <div class="container px-4 px-lg-5 my-4 text-center">
+    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
+         class="img-fluid rounded-top mx-auto mb-3">
+    <div class="post-heading">
+      <h1>{{ title }}</h1>
+      <span class="meta">{{ date }}</span>
     </div>
   </div>
 </header>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,14 +1,12 @@
 {% extends 'base.html' %}
 
 {% block header %}
-<header class="masthead" style="background-image: url('{{ config.site.hero_image_url }}')">
-  <div class="container position-relative px-4 px-lg-5">
-    <div class="row gx-4 gx-lg-5 justify-content-center">
-      <div class="col-md-10 col-lg-8 col-xl-7">
-        <div class="page-heading">
-          <h1>Tag: {{ tag_name }}</h1>
-        </div>
-      </div>
+<header class="masthead">
+  <div class="container px-4 px-lg-5 my-4 text-center">
+    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
+         class="img-fluid rounded-top mx-auto mb-3">
+    <div class="page-heading">
+      <h1>Tag: {{ tag_name }}</h1>
     </div>
   </div>
 </header>

--- a/templates/tags_list.html
+++ b/templates/tags_list.html
@@ -1,14 +1,12 @@
 {% extends 'base.html' %}
 
 {% block header %}
-<header class="masthead" style="background-image: url('{{ config.site.hero_image_url }}')">
-  <div class="container position-relative px-4 px-lg-5">
-    <div class="row gx-4 gx-lg-5 justify-content-center">
-      <div class="col-md-10 col-lg-8 col-xl-7">
-        <div class="page-heading">
-          <h1>All Tags</h1>
-        </div>
-      </div>
+<header class="masthead">
+  <div class="container px-4 px-lg-5 my-4 text-center">
+    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
+         class="img-fluid rounded-top mx-auto mb-3">
+    <div class="page-heading">
+      <h1>All Tags</h1>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- require Pillow explicitly and remove fallback logic
- use `<img>` hero images so `apply_responsive_images` can add mobile/desktop variants

## Testing
- `python3 run_tests.py` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `python3 generate_site.py` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_b_68405ffc42ec833188ff75dee33d3f20