### PR TITLE
Adjust hero layout on home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,11 +2,11 @@
 {% block header %}
 <header class="masthead">
   <div class="container px-4 px-lg-5 my-4 text-center">
-    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
-         class="img-fluid rounded-top mx-auto mb-3">
-    <div class="site-heading">
+    <div class="site-heading mb-3">
       <h1>{{ site_title }}</h1>
     </div>
+    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
+         class="img-fluid rounded-top mx-auto">
   </div>
 </header>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show blog title above the hero image on the main page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6840640eda188331a78aab84d5cb5299