### PR TITLE
Apply hero as header background

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -18,3 +18,14 @@ article blockquote {
 article hr {
     margin: 2em 0; /* More spacing around horizontal rules */
 }
+
+/* Hero background adjustments */
+header.masthead {
+    padding-top: 0;
+    padding-bottom: 0;
+    aspect-ratio: 16 / 9;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,11 @@
 {% extends 'base.html' %}
 {% block header %}
-<header class="masthead">
+{% set hero = config.site.hero_image_url %}
+<header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
     <div class="site-heading mb-3">
       <h1>{{ site_title }}</h1>
     </div>
-    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
-         class="img-fluid rounded-top mx-auto">
   </div>
 </header>
 {% endblock %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,9 +1,8 @@
 {% extends 'base.html' %}
 {% block header %}
-<header class="masthead">
+{% set hero = config.site.hero_image_url %}
+<header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
-    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
-         class="img-fluid rounded-top mx-auto mb-3">
     <div class="page-heading">
       <h1>{{ title }}</h1>
     </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,9 +1,8 @@
 {% extends 'base.html' %}
 {% block header %}
-<header class="masthead">
+{% set hero = config.site.hero_image_url %}
+<header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
-    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
-         class="img-fluid rounded-top mx-auto mb-3">
     <div class="post-heading">
       <h1>{{ title }}</h1>
       <span class="meta">{{ date }}</span>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,10 +1,9 @@
 {% extends 'base.html' %}
 
 {% block header %}
-<header class="masthead">
+{% set hero = config.site.hero_image_url %}
+<header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
-    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
-         class="img-fluid rounded-top mx-auto mb-3">
     <div class="page-heading">
       <h1>Tag: {{ tag_name }}</h1>
     </div>

--- a/templates/tags_list.html
+++ b/templates/tags_list.html
@@ -1,10 +1,9 @@
 {% extends 'base.html' %}
 
 {% block header %}
-<header class="masthead">
+{% set hero = config.site.hero_image_url %}
+<header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
-    <img src="{{ config.site.hero_image_url }}" alt="Hero image"
-         class="img-fluid rounded-top mx-auto mb-3">
     <div class="page-heading">
       <h1>All Tags</h1>
     </div>


### PR DESCRIPTION
## Summary
- show hero image as background in header blocks
- add CSS to force masthead area to 16:9

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6840a12a3c3c8331b4faea04bd378dc8