### PR TITLE
Improve hero layout and mobile image

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -23,7 +23,8 @@ article hr {
 header.masthead {
     padding-top: 0;
     padding-bottom: 0;
-    aspect-ratio: 16 / 9;
+    /* Match hero image ratio 1536x1024 (3:2) */
+    aspect-ratio: 3 / 2;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,16 @@
   <!-- Core theme CSS (includes Bootstrap)-->
   <link href="{{ base_url }}styles.css" rel="stylesheet" />
   <link rel="stylesheet" href="{{ base_url }}custom.css">
+  {% set hero = config.site.hero_image_url %}
+  {% if hero %}
+    {% set parts = hero.rsplit('.', 1) %}
+    {% set hero_mobile = parts[0] ~ '-mobile.' ~ parts[1] %}
+    <style>
+      @media (max-width: 600px) {
+        header.masthead { background-image: url('{{ hero_mobile }}'); }
+      }
+    </style>
+  {% endif %}
   {% for snippet in plugins_head %}
   {{ snippet | safe }}
   {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block header %}
-{% set hero = config.site.hero_image_url %}
 <header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
     <div class="site-heading mb-3">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block header %}
-{% set hero = config.site.hero_image_url %}
 <header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
     <div class="page-heading">

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block header %}
-{% set hero = config.site.hero_image_url %}
 <header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
     <div class="post-heading">

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 
 {% block header %}
-{% set hero = config.site.hero_image_url %}
 <header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
     <div class="page-heading">

--- a/templates/tags_list.html
+++ b/templates/tags_list.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 
 {% block header %}
-{% set hero = config.site.hero_image_url %}
 <header class="masthead" {% if hero %}style="background-image: url('{{ hero }}');"{% endif %}>
   <div class="container px-4 px-lg-5 my-4 text-center">
     <div class="page-heading">


### PR DESCRIPTION
## Summary
- tweak hero masthead ratio
- add mobile hero image style
- refactor templates to use common hero variable

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6840a962fbf4833186b83c7861ab6da2